### PR TITLE
verit also works when it doesn't use the conclusion

### DIFF
--- a/examples/Example.v
+++ b/examples/Example.v
@@ -191,7 +191,7 @@ Section mult3.
   Hypothesis mult3_Sn : forall n, mult3 (n+1) =? mult3 n + 3.
   Add_lemmas mult3_0 mult3_Sn.
 
-  Lemma mult3_21 : mult3 7 =? 21.
+  Lemma mult3_21 : mult3 4 =? 12.
   Proof. verit. Qed.
 
   Clear_lemmas.

--- a/src/trace/smtCertif.mli
+++ b/src/trace/smtCertif.mli
@@ -44,3 +44,4 @@ and 'hform resolution = {
 }
 val used_clauses : 'a rule -> 'a clause list
 val to_string : 'a clause_kind -> string
+val print_certif : ('a -> Format.formatter -> 'b -> 'c) -> 'a -> 'b clause -> string -> unit

--- a/src/trace/smtForm.ml
+++ b/src/trace/smtForm.ml
@@ -449,7 +449,9 @@ module Make (Atom:ATOM) =
 
     (** Producing Coq terms *)
 
-    let to_coq hf = mkInt (to_lit hf)
+    let to_coq hf = let i = to_lit hf in
+                    if i < 0 then failwith "This formula should'nt be in Coq"
+                    else mkInt i
 
     let args_to_coq args =
       let cargs = Array.make (Array.length args + 1) (mkInt 0) in

--- a/unit-tests/Tests_verit.v
+++ b/unit-tests/Tests_verit.v
@@ -1045,6 +1045,12 @@ Lemma lcongr3 (P:Z -> Z -> bool) x y z:
   x =? y -> P z x -> P z y.
 Proof. intros eqxy pzx. verit_base eqxy pzx; vauto. Qed.
 
+Lemma test20 :  forall x, (forall a, a <? x) -> 0 <=? x = false.
+Proof. intros x H. verit_base H; vauto. Qed.
+
+Lemma test21 : forall x, (forall a, negb (x <=? a)) -> negb (0 <=? x).
+Proof. intros x H. verit_base H; vauto. Qed.
+
 Lemma un_menteur (a b c d : Z) dit:
   dit a =? c ->
   dit b =? d ->
@@ -1123,8 +1129,8 @@ Section mult3.
   Hypothesis mult3_Sn : forall n, mult3 (n+1) =? mult3 n + 3.
   Add_lemmas mult3_0 mult3_Sn.
 
-  Lemma mult3_21 : mult3 14 =? 42.
-  Proof. verit. Qed. (* very slow to verify with standard coq *)
+  Lemma mult3_21 : mult3 4 =? 12.
+  Proof. verit. Qed. (* slow to verify with standard coq *)
 
   Clear_lemmas.
 End mult3.


### PR DESCRIPTION
This commit fixes issue #20 which arise when the conclusion of the current lemma is not used (veriT proves False from the hypotheses). In such a case, the conclusion does not appear as an input of the problem in the veriT certificate; to process it (see verit.ml) we should take that into account.