### PR TITLE
Search correctly for `num` library

### DIFF
--- a/src/versions/standard/Makefile.local
+++ b/src/versions/standard/Makefile.local
@@ -22,6 +22,10 @@ clean::
 
 CAMLLEX = $(CAMLBIN)ocamllex
 CAMLYACC = $(CAMLBIN)ocamlyacc
+CAMLPKGS += -package num
+
+merlin-hook::
+	$(HIDE)echo 'PKG num' >> .merlin
 
 %.ml :  %.mll
 	$(CAMLLEX) $<


### PR DESCRIPTION
We fix the way SMTCoq searches for the num library, both when building
and when generating .merlin.