### PR TITLE
Revert "Search correctly for `num` library"

### DIFF
--- a/src/versions/standard/Makefile.local
+++ b/src/versions/standard/Makefile.local
@@ -22,10 +22,6 @@ clean::
 
 CAMLLEX = $(CAMLBIN)ocamllex
 CAMLYACC = $(CAMLBIN)ocamlyacc
-CAMLPKGS += -package num
-
-merlin-hook::
-	$(HIDE)echo 'PKG num' >> .merlin
 
 %.ml :  %.mll
 	$(CAMLLEX) $<


### PR DESCRIPTION
Reverts smtcoq/smtcoq#60: does not compile with ocaml 4.08.x nor 4.09.0