### PR TITLE
CompDec clean-up

### DIFF
--- a/src/QInst.v
+++ b/src/QInst.v
@@ -88,14 +88,7 @@ Qed.
 (* An auxiliary lemma to rewrite an eqb_of_compdec into its the symmetrical version *)
 Lemma eqb_of_compdec_sym (A:Type) (HA:CompDec A) (a b:A) :
   eqb_of_compdec HA b a = eqb_of_compdec HA a b.
-Proof.
-  destruct (@eq_dec _ (@Decidable _ HA) a b) as [H|H].
-  - now rewrite H.
-  - case_eq (eqb_of_compdec HA a b).
-    + now rewrite <- !(@compdec_eq_eqb _ HA).
-    + intros _. case_eq (eqb_of_compdec HA b a); auto.
-      intro H1. elim H. symmetry. now rewrite compdec_eq_eqb.
-Qed.
+Proof. apply eqb_sym2. Qed.
 
 (* First strategy: change the order of all equalities in the goal or the
    hypotheses

--- a/src/SMT_terms.v
+++ b/src/SMT_terms.v
@@ -391,11 +391,7 @@ Module Typ.
       Qed.
 
      Lemma i_eqb_sym : forall t x y, i_eqb t x y = i_eqb t y x.
-     Proof.
-       intros t x y; case_eq (i_eqb t x y); intro H1; symmetry;
-          [ | rewrite neg_eq_true_eq_false in *; intro H2; apply H1];
-          rewrite is_true_iff in *; now rewrite i_eqb_spec in *.
-      Qed.
+     Proof. intros. apply eqb_sym2. Qed.
 
 
       Definition i_eqb_eqb (t:type) : interp t -> interp t -> bool :=

--- a/src/array/Array_checker.v
+++ b/src/array/Array_checker.v
@@ -380,8 +380,11 @@ Section certif.
 
         rewrite H6d1, H6d2, H14.
         intros.
-        specialize (Atom.Bval_inj2 t_i (Typ.TFArray t0 t) 
-        (store v_val2 v_val3 v_val4) (v_val0)).
+        specialize (Atom.Bval_inj2 t_i (Typ.TFArray t0 t)
+          (@store _ _
+                  (@EqbToDecType _ (@eqbtype_of_compdec _ (Typ.interp_compdec t_i t0)))
+               _ _ _ (Typ.comp_interp t_i t) _
+               v_val2 v_val3 v_val4) v_val0).
         intros. specialize (H18 H6).
         rewrite <- H18.
 
@@ -397,7 +400,8 @@ Section certif.
         intros. specialize (H20 Htia2).
         rewrite <- H20.
         apply Typ.i_eqb_spec.
-        apply (read_over_write (elt_dec:=(EqbToDecType _ (@Eqb _ _)))).
+        apply (read_over_write (elt_dec:=(@EqbToDecType _ (@Eqb _
+                   (projT2 (Typ.interp_compdec_aux t_i _)))))).
     Qed.
 
 
@@ -677,9 +681,12 @@ Section certif.
 
           rewrite H25a, H25b, H10. intros.
           specialize (Atom.Bval_inj2 t_i (Typ.TFArray t1 t2)
-                                     (store v_vale1 v_vale2 v_vale3) (v_vald1')).
+            (@store _ _
+                    (@EqbToDecType _ (@eqbtype_of_compdec _ (Typ.interp_compdec t_i t1)))
+                   _ _ _ (Typ.comp_interp t_i t2) _
+                   v_vale1 v_vale2 v_vale3) (v_vald1')).
           intro H25. specialize (H25 Htid1').
-          
+
           unfold Atom.interp_form_hatom, interp_hatom.
           rewrite !Atom.t_interp_wf; trivial.
           rewrite Heq6. simpl.
@@ -725,7 +732,7 @@ Section certif.
             subst; intros;
 
               rewrite Htid2 in Htic2;
-              rewrite <- (Atom.Bval_inj2 _ _  (v_vald2) (v_valc2) Htic2) in *. 
+              rewrite <- (Atom.Bval_inj2 _ _  (v_vald2) (v_valc2) Htic2) in *.
           
           + rewrite Htie2 in Htia1.
             rewrite Htia2 in Htic2''.
@@ -831,7 +838,10 @@ Section certif.
 
           rewrite H25a, H25b, H10. intros.
           specialize (Atom.Bval_inj2 t_i (Typ.TFArray t1 t2)
-                                     (store v_vale1 v_vale2 v_vale3) (v_valc1')).
+            (@store _ _
+                   (@EqbToDecType _ (@eqbtype_of_compdec _ (Typ.interp_compdec t_i t1)))
+                   _ _ _ (Typ.comp_interp t_i t2) _
+                   v_vale1 v_vale2 v_vale3) (v_valc1')).
           intro H25. specialize (H25 Htic1').
           
           unfold Atom.interp_form_hatom, interp_hatom.
@@ -878,7 +888,7 @@ Section certif.
             subst; intros;
 
               rewrite Htid2 in Htic2;
-              rewrite <- (Atom.Bval_inj2 _ _  (v_vald2) (v_valc2) Htic2) in *. 
+              rewrite <- (Atom.Bval_inj2 _ _  (v_vald2) (v_valc2) Htic2) in *.
           
           + rewrite Htie2 in Htia1.
             rewrite Htia2 in Htic2''.
@@ -1169,7 +1179,10 @@ Section certif.
     unfold Bval. rewrite <- H25.
     rewrite !Typ.cast_refl. intros.
 
-    specialize (Atom.Bval_inj2 t_i t0 (diff v_valf1 v_valf2) (v_vald2')).
+    specialize (Atom.Bval_inj2 t_i t0 (@diff _ _
+       (@EqbToDecType _ (@eqbtype_of_compdec _ (Typ.interp_compdec t_i t0)))
+       _ _ (Typ.dec_interp t_i v_typec2') _ (Typ.comp_interp t_i v_typec2') (Typ.inh_interp t_i t0) _
+       v_valf1 v_valf2) (v_vald2')).
     intros. specialize (H29 Htid2').
 
     (* semantics *)
@@ -1212,7 +1225,57 @@ Section certif.
     apply negb_true_iff.
     apply Typ.i_eqb_spec_false.
     subst.
-    specialize (Atom.Bval_inj2 t_i v_typed2' (v_vald2) (diff v_valf1 v_valf2)).
+    specialize (Atom.Bval_inj2 t_i v_typed2' (v_vald2) (@diff (Typ.interp t_i v_typed2') (Typ.interp t_i v_typec1')
+             (@EqbToDecType
+                _
+                (@eqbtype_of_compdec
+                   _
+                   (Typ.interp_compdec t_i v_typed2')))
+             _
+             (@comp_of_compdec (Typ.interp t_i v_typed2')
+                (projT2
+                   ((fix interp_compdec_aux (t : Typ.type) :
+                       @sigT Type (fun ty : Type => CompDec ty) :=
+                       match t return (@sigT Type (fun ty : Type => CompDec ty)) with
+                       | Typ.TFArray ti te =>
+                           @existT Type (fun ty : Type => CompDec ty)
+                             (@farray
+                                (@projT1 Type (fun ty : Type => CompDec ty) (interp_compdec_aux ti))
+                                (@projT1 Type (fun ty : Type => CompDec ty) (interp_compdec_aux te))
+                                (@ord_of_compdec
+                                   (@projT1 Type (fun ty : Type => CompDec ty)
+                                      (interp_compdec_aux ti))
+                                   (@projT2 Type (fun ty : Type => CompDec ty)
+                                      (interp_compdec_aux ti)))
+                                (@inh_of_compdec
+                                   (@projT1 Type (fun ty : Type => CompDec ty)
+                                      (interp_compdec_aux te))
+                                   (@projT2 Type (fun ty : Type => CompDec ty)
+                                      (interp_compdec_aux te))))
+                             (@SMT_classes_instances.FArray_compdec
+                                (@projT1 Type (fun ty : Type => CompDec ty) (interp_compdec_aux ti))
+                                (@projT1 Type (fun ty : Type => CompDec ty) (interp_compdec_aux te))
+                                (@projT2 Type (fun ty : Type => CompDec ty) (interp_compdec_aux ti))
+                                (@projT2 Type (fun ty : Type => CompDec ty) (interp_compdec_aux te)))
+                       | Typ.Tindex i =>
+                           @existT Type (fun ty : Type => CompDec ty)
+                             (te_carrier (@get typ_compdec t_i i))
+                             (te_compdec (@get typ_compdec t_i i))
+                       | Typ.TZ =>
+                           @existT Type (fun ty : Type => CompDec ty) BinNums.Z
+                             SMT_classes_instances.Z_compdec
+                       | Typ.Tbool =>
+                           @existT Type (fun ty : Type => CompDec ty) bool
+                             SMT_classes_instances.bool_compdec
+                       | Typ.Tpositive =>
+                           @existT Type (fun ty : Type => CompDec ty) BinNums.positive
+                             SMT_classes_instances.Positive_compdec
+                       | Typ.TBV n =>
+                           @existT Type (fun ty : Type => CompDec ty)
+                             (BVList.BITVECTOR_LIST.bitvector n) (SMT_classes_instances.BV_compdec n)
+                       end) v_typed2'))) (Typ.dec_interp t_i v_typec1')
+             _ (Typ.comp_interp t_i v_typec1')
+             (Typ.inh_interp t_i v_typed2') (Typ.inh_interp t_i v_typec1') v_valf1 v_valf2)).
     intros. specialize (H5 Htid2''').
     rewrite <- H5.
     specialize (Atom.Bval_inj2 t_i v_typed2' (v_vale2) (v_vald2)).

--- a/src/array/FArray.v
+++ b/src/array/FArray.v
@@ -29,12 +29,11 @@ Module Raw.
 
   Variable key : Type.
   Variable elt : Type.
+  Variable key_dec : DecType key.
   Variable key_ord : OrdType key.
   Variable key_comp : Comparable key.
   Variable elt_dec : DecType elt.
   Variable elt_ord : OrdType elt.
-
-  Instance key_dec : DecType key := @EqbToDecType _ Comparable2EqbType.
 
   Definition eqb_key (x y : key) : bool := if eq_dec x y then true else false.
   Definition eqb_elt (x y : elt) : bool := if eq_dec x y then true else false.
@@ -921,22 +920,14 @@ Section FArray.
 
   Variable key : Type.
   Variable elt : Type.
+  Variable key_dec : DecType key.
   Variable key_ord : OrdType key.
   Variable key_comp : Comparable key.
+  Variable elt_dec : DecType elt.
   Variable elt_ord : OrdType elt.
   Variable elt_comp : Comparable elt.
   Variable key_inh :  Inhabited key.
   Variable elt_inh :  Inhabited elt.
-
-  Instance key_dec : DecType key := @EqbToDecType _ Comparable2EqbType.
-  Instance elt_dec : DecType elt := @EqbToDecType _ Comparable2EqbType.
-
-  (* Variable key_dec : DecType key. *)
-  (* Variable key_ord : OrdType key. *)
-  (* Variable key_comp : Comparable key. *)
-  (* Variable elt_dec : DecType elt. *)
-  (* Variable elt_ord : OrdType elt. *)
-  (* Variable elt_comp : Comparable elt. *)
 
   Set Implicit Arguments.
 
@@ -1447,7 +1438,7 @@ Section FArray.
               + intro. contradiction.
               + intro. contradict H0.
                 apply Raw.remove_1; auto.
-            - apply Raw.remove_4; auto. apply (@EqbToDecType _ Comparable2EqbType).
+            - apply Raw.remove_4; auto.
           }
         * { intros k e e' H0 H1.
             destruct (eq_dec x k) as [e0|n].
@@ -1457,7 +1448,6 @@ Section FArray.
               + contradict H2.
                 apply Raw.remove_1; auto.
               + apply key_comp.
-              + apply (@EqbToDecType _ Comparable2EqbType).
             - apply (Raw.remove_2 key_comp Hm n) in H0.
               specialize (Raw.remove_sorted key_comp Hm x). intros H2.
               specialize (Raw.MapsTo_inj H2 H0 H1).
@@ -1494,7 +1484,6 @@ Section FArray.
     - contradict H1.
       apply remove_1; auto.
     - apply key_comp.
-    - apply (@EqbToDecType _ Comparable2EqbType).
   Qed.
 
   Lemma add_neq_o : forall m x y e,
@@ -1735,7 +1724,7 @@ Section FArray.
                  a <> b -> {i : key | select a i <> select b i}).
       {
         clear a b. intros x y.
-        case_eq (list_eq_dec (@eq_dec _ (Raw.ke_dec key_comp (@EqbToDecType _ Comparable2EqbType))) x y).
+        case_eq (list_eq_dec (@eq_dec _ (Raw.ke_dec key_dec elt_dec)) x y).
         - intros e He. subst x. intros xS yS xD yD a b. subst a b.
           rewrite (proof_irrelevance _ xS yS),  (proof_irrelevance _ xD yD).
           intro H. elim H. reflexivity.

--- a/src/array/FArray.v
+++ b/src/array/FArray.v
@@ -1842,8 +1842,8 @@ End FArray.
 
 Arguments farray _ _ {_} {_}.
 Arguments select {_} {_} {_} {_} {_} _ _.
-Arguments store {_} {_} {_} {_} {_} {_} {_} _ _ _.
-Arguments diff {_} {_} {_} {_} {_} {_} {_} {_} _ _.
+Arguments store {_} {_} {_} {_} {_} {_} {_} {_} _ _ _.
+Arguments diff {_} {_} {_} {_} {_} {_} {_} {_} {_} {_} _ _.
 Arguments equal {_} {_} {_} {_} {_} {_} {_}  _ _.
 Arguments equal_iff_eq {_} {_} {_} {_} {_} {_} {_} _ _.
 Arguments read_over_same_write {_} {_} {_} {_} {_} {_} {_} _ _ _ _ _.

--- a/src/bva/Bva_checker.v
+++ b/src/bva/Bva_checker.v
@@ -1179,132 +1179,132 @@ Proof. intro la.
 Qed.
 
 Lemma valid_check_bbDiseq lres : C.valid rho (check_bbDiseq lres).
-Proof. 
-      unfold check_bbDiseq.
-      case_eq (Lit.is_pos lres); intro Heq; simpl; try now apply C.interp_true.
-      case_eq (t_form .[ Lit.blit lres]); try (intros; now apply C.interp_true).
-        intros f Heq2.
-      case_eq (t_atom .[ f]); try (intros; now apply C.interp_true).
+Proof.
+  unfold check_bbDiseq.
+  case_eq (Lit.is_pos lres); intro Heq; simpl; try now apply C.interp_true.
+  case_eq (t_form .[ Lit.blit lres]); try (intros; now apply C.interp_true).
+  intros f Heq2.
+  case_eq (t_atom .[ f]); try (intros; now apply C.interp_true).
 
-      intros [ | | | | | | |[ A B | A| | | |n]|N|N|N|N|N|N|N|N| | | | ];
-         try (intros; now apply C.interp_true). intros a b Heq3.
-      case_eq (t_atom .[ a]); try (intros; now apply C.interp_true).
-      intros c Heq4.
-      case_eq c; try (intros; now apply C.interp_true).
-      intros la n1 Heq5.
-      case_eq (t_atom .[ b]); try (intros; now apply C.interp_true).
-      intros c0 Heq6.
-      case_eq c0; try (intros; now apply C.interp_true).
-      intros lb n2 Heq7.
-      case_eq (List_diseqb la lb && (N.of_nat (Datatypes.length la) =? n)%N
-              && (N.of_nat (Datatypes.length lb) =? n)%N 
-              && (n1 =? n)%N && (n2 =? n)%N);
-         try (intros; now apply C.interp_true). intros Heq8.
+  intros [ | | | | | | |[ A B | A| | | |n]|N|N|N|N|N|N|N|N| | | | ];
+    try (intros; now apply C.interp_true). intros a b Heq3.
+  case_eq (t_atom .[ a]); try (intros; now apply C.interp_true).
+  intros c Heq4.
+  case_eq c; try (intros; now apply C.interp_true).
+  intros la n1 Heq5.
+  case_eq (t_atom .[ b]); try (intros; now apply C.interp_true).
+  intros c0 Heq6.
+  case_eq c0; try (intros; now apply C.interp_true).
+  intros lb n2 Heq7.
+  case_eq (List_diseqb la lb && (N.of_nat (Datatypes.length la) =? n)%N
+           && (N.of_nat (Datatypes.length lb) =? n)%N
+           && (n1 =? n)%N && (n2 =? n)%N);
+    try (intros; now apply C.interp_true). intros Heq8.
 
-      unfold C.valid. simpl. rewrite orb_false_r.
-      unfold Lit.interp. rewrite Heq.
-      unfold Var.interp.
-      rewrite wf_interp_form; trivial. rewrite Heq2. simpl.
-      unfold Atom.interp_form_hatom, interp_hatom.
-      rewrite Atom.t_interp_wf; trivial.
-      rewrite Heq3. simpl.
-      rewrite !Atom.t_interp_wf; trivial.
-      rewrite Heq4, Heq6. simpl.
-      rewrite Heq5, Heq7. simpl.
+  unfold C.valid. simpl. rewrite orb_false_r.
+  unfold Lit.interp. rewrite Heq.
+  unfold Var.interp.
+  rewrite wf_interp_form; trivial. rewrite Heq2. simpl.
+  unfold Atom.interp_form_hatom, interp_hatom.
+  rewrite Atom.t_interp_wf; trivial.
+  rewrite Heq3. simpl.
+  rewrite !Atom.t_interp_wf; trivial.
+  rewrite Heq4, Heq6. simpl.
+  rewrite Heq5, Heq7. simpl.
 
-        rewrite !andb_true_iff in Heq8.
-        destruct Heq8 as (((Heq8, Ha), Hb), Hc).
-        destruct Heq8 as (Heq8, Hd).
-        rewrite N.eqb_eq in Hb, Hc.
-        rewrite Hb, Hc.
-        rewrite Typ.N_cast_refl. simpl.
+  rewrite !andb_true_iff in Heq8.
+  destruct Heq8 as (((Heq8, Ha), Hb), Hc).
+  destruct Heq8 as (Heq8, Hd).
+  rewrite N.eqb_eq in Hb, Hc.
+  rewrite Hb, Hc.
+  rewrite Typ.N_cast_refl. simpl.
 
-        generalize wt_t_atom. unfold Atom.wt. unfold is_true.
-        rewrite PArray.forallbi_spec;intros.
+  generalize wt_t_atom. unfold Atom.wt. unfold is_true.
+  rewrite PArray.forallbi_spec;intros.
 
-        (* a *)
-        pose proof (H a). 
-        assert (a < PArray.length t_atom).
-        { apply PArray.get_not_default_lt. rewrite def_t_atom. rewrite Heq4, Heq5. easy. }
-        specialize (@H0 H1). rewrite Heq4 in H0. simpl in H0.
-        unfold get_type' in H0. unfold v_type in H0.
-        case_eq (t_interp .[ a]).
-        intros v_typea v_vala Htia. rewrite Htia in H0.
-        rewrite Atom.t_interp_wf in Htia; trivial.
-        rewrite Heq4, Heq5 in Htia. simpl in Htia.
-        rewrite Hb in Htia.
-        unfold Bval in Htia.
-        rewrite Heq5 in H0. simpl in H0.
-        inversion Htia.
+  (* a *)
+  pose proof (H a).
+  assert (H1: a < PArray.length t_atom).
+  { apply PArray.get_not_default_lt. rewrite def_t_atom. rewrite Heq4, Heq5. easy. }
+  specialize (@H0 H1). rewrite Heq4 in H0. simpl in H0.
+  unfold get_type' in H0. unfold v_type in H0.
+  case_eq (t_interp .[ a]).
+  intros v_typea v_vala Htia. rewrite Htia in H0.
+  rewrite Atom.t_interp_wf in Htia; trivial.
+  rewrite Heq4, Heq5 in Htia. simpl in Htia.
+  rewrite Hb in Htia.
+  unfold Bval in Htia.
+  rewrite Heq5 in H0. simpl in H0.
+  inversion Htia.
 
-        generalize dependent v_vala.
-        rewrite <- H3. intros.
+  generalize dependent v_vala.
+  rewrite <- H3. intros.
 
-        (* b *)
-        pose proof (H b). 
-        assert (b < PArray.length t_atom).
-        { apply PArray.get_not_default_lt. rewrite def_t_atom. rewrite Heq6, Heq7. easy. }
-        specialize (@H2 H4). rewrite Heq6 in H2. simpl in H2.
-        unfold get_type' in H2. unfold v_type in H2.
-        case_eq (t_interp .[ b]).
-        intros v_typeb v_valb Htib. rewrite Htib in H2.
-        rewrite Atom.t_interp_wf in Htib; trivial.
-        rewrite Heq6, Heq7 in Htib. simpl in Htib.
-        rewrite Hc in Htib.
-        unfold Bval in Htib.
-        rewrite Heq7 in H2. simpl in H2.
-        inversion Htib.
+  (* b *)
+  pose proof (H b).
+  assert (H4: b < PArray.length t_atom).
+  { apply PArray.get_not_default_lt. rewrite def_t_atom. rewrite Heq6, Heq7. easy. }
+  specialize (@H2 H4). rewrite Heq6 in H2. simpl in H2.
+  unfold get_type' in H2. unfold v_type in H2.
+  case_eq (t_interp .[ b]).
+  intros v_typeb v_valb Htib. rewrite Htib in H2.
+  rewrite Atom.t_interp_wf in Htib; trivial.
+  rewrite Heq6, Heq7 in Htib. simpl in Htib.
+  rewrite Hc in Htib.
+  unfold Bval in Htib.
+  rewrite Heq7 in H2. simpl in H2.
+  inversion Htib.
 
-        generalize dependent v_valb.
-        rewrite <- H6. intros.
+  generalize dependent v_valb.
+  rewrite <- H6. intros.
 
-        (* f *)
-        pose proof (H f). 
-        assert (f < PArray.length t_atom).
-        { apply PArray.get_not_default_lt. rewrite def_t_atom. rewrite Heq3. easy. }
-        specialize (@H5 H7). rewrite Heq3 in H5. simpl in H5.
-        unfold get_type' in H5. unfold v_type in H5.
-        case_eq (t_interp .[ f]).
-        intros v_typef v_valf Htif. rewrite Htif in H5.
-        rewrite Atom.t_interp_wf in Htif; trivial.
-        rewrite Heq3 in Htif. simpl in Htif.
-        rewrite !Atom.t_interp_wf in Htif; trivial.
-        rewrite Heq4, Heq6 in Htif.
-        rewrite Heq5, Heq7 in Htif.
-        simpl in Htif.
-        rewrite Hb, Hc in Htif.
-        rewrite Typ.N_cast_refl in Htif.
-        unfold Bval in Htif.
-        rewrite !andb_true_iff in H5.
-        destruct H5. destruct H5.
+  (* f *)
+  pose proof (H f).
+  assert (H7: f < PArray.length t_atom).
+  { apply PArray.get_not_default_lt. rewrite def_t_atom. rewrite Heq3. easy. }
+  specialize (@H5 H7). rewrite Heq3 in H5. simpl in H5.
+  unfold get_type' in H5. unfold v_type in H5.
+  case_eq (t_interp .[ f]).
+  intros v_typef v_valf Htif. rewrite Htif in H5.
+  rewrite Atom.t_interp_wf in Htif; trivial.
+  rewrite Heq3 in Htif. simpl in Htif.
+  rewrite !Atom.t_interp_wf in Htif; trivial.
+  rewrite Heq4, Heq6 in Htif.
+  rewrite Heq5, Heq7 in Htif.
+  simpl in Htif.
+  rewrite Hb, Hc in Htif.
+  rewrite Typ.N_cast_refl in Htif.
+  unfold Bval in Htif.
+  rewrite !andb_true_iff in H5.
+  destruct H5. destruct H5.
 
-        inversion Htif.
+  inversion Htif.
 
-        generalize dependent v_valf.
-        rewrite <- H11. intros.
+  generalize dependent v_valf.
+  rewrite <- H11. intros.
 
-        unfold BITVECTOR_LIST._of_bits, RAWBITVECTOR_LIST._of_bits.
-        rewrite N.eqb_eq in Ha, Hd.
+  unfold BITVECTOR_LIST._of_bits, RAWBITVECTOR_LIST._of_bits.
+  rewrite N.eqb_eq in Ha, Hd.
 
-        generalize (BITVECTOR_LIST._of_bits_size la n).
+  generalize (BITVECTOR_LIST._of_bits_size la n).
 
-        unfold BITVECTOR_LIST._of_bits, RAWBITVECTOR_LIST._of_bits.
+  unfold BITVECTOR_LIST._of_bits, RAWBITVECTOR_LIST._of_bits.
 
-        rewrite Hd.
+  rewrite Hd.
 
-        generalize (BITVECTOR_LIST._of_bits_size lb n).
-        unfold BITVECTOR_LIST._of_bits, RAWBITVECTOR_LIST._of_bits.
-        rewrite Ha.
-        intros.
+  generalize (BITVECTOR_LIST._of_bits_size lb n).
+  unfold BITVECTOR_LIST._of_bits, RAWBITVECTOR_LIST._of_bits.
+  rewrite Ha.
+  intros.
 
-        unfold Typ.i_eqb. simpl.
-        unfold BITVECTOR_LIST.bv_eq, RAWBITVECTOR_LIST.bv_eq.
-        simpl.
-        rewrite e, e0.
-        rewrite N.eqb_refl.
-        unfold RAWBITVECTOR_LIST.bits.
+  change (Typ.i_eqb t_i (Typ.TBV n)) with (@BITVECTOR_LIST.bv_eq n).
+  unfold BITVECTOR_LIST.bv_eq, RAWBITVECTOR_LIST.bv_eq.
+  simpl.
+  rewrite e, e0.
+  rewrite N.eqb_refl.
+  unfold RAWBITVECTOR_LIST.bits.
 
-        apply diseq_neg_eq. easy.
+  apply diseq_neg_eq. easy.
 Qed.
 
 Lemma prop_checkbb: forall (a: int) (bs: list _lit) (i n: nat),
@@ -4718,8 +4718,8 @@ Lemma valid_check_bbEq pos1 pos2 lres : C.valid rho (check_bbEq pos1 pos2 lres).
        (** case symmetry **)
 
 
-        (* interp_form_hatom_bv a1' = 
-                 interp_bv t_i (interp_atom (t_atom .[a1'])) *)
+        (* interp_form_hatom_bv a1' =  *)
+(*                  interp_bv t_i (interp_atom (t_atom .[a1'])) *)
         assert (interp_form_hatom_bv a1' =
                 interp_bv t_i (interp_atom (t_atom .[a1']))).
         {
@@ -4737,8 +4737,8 @@ Lemma valid_check_bbEq pos1 pos2 lres : C.valid rho (check_bbEq pos1 pos2 lres).
         rewrite Htia1 in HSp2.
         unfold interp_bv in HSp2.
 
-        (* interp_form_hatom_bv a2' =
-                 interp_bv t_i (interp_atom (t_atom .[a2'])) *)
+        (* interp_form_hatom_bv a2' = *)
+(*                  interp_bv t_i (interp_atom (t_atom .[a2'])) *)
         assert (interp_form_hatom_bv a2' =
                 interp_bv t_i (interp_atom (t_atom .[a2']))).
         {

--- a/src/classes/SMT_classes.v
+++ b/src/classes/SMT_classes.v
@@ -81,6 +81,13 @@ Section EqbTypeProp.
     - now rewrite eqb_spec in H.
     - now rewrite eqb_spec_false in H.
   Qed.
+
+  Lemma eqb_sym2 x y : eqb x y = eqb y x.
+  Proof.
+    case_eq (eqb y x); intro H.
+    - now apply eqb_sym.
+    - rewrite eqb_spec_false in *. auto.
+  Qed.
 End EqbTypeProp.
 
 

--- a/src/classes/SMT_classes.v
+++ b/src/classes/SMT_classes.v
@@ -28,7 +28,7 @@ Definition eqb_to_eq_dec :
   Defined.
 
 
-(** Types with a Boolean equality that reflects in Leibniz equality *)
+(** Types with a Boolean equality that reflects Leibniz equality *)
 Class EqbType T := {
  eqb : T -> T -> bool;
  eqb_spec : forall x y, eqb x y = true <-> x = y
@@ -37,32 +37,34 @@ Class EqbType T := {
 
 (** Types with a decidable equality *)
 Class DecType T := {
- eq_refl : forall x : T, x = x;
- eq_sym : forall x y : T, x = y -> y = x;
- eq_trans : forall x y z : T, x = y -> y = z -> x = z;
+ (* eq_refl : forall x : T, x = x; *)
+ (* eq_sym : forall x y : T, x = y -> y = x; *)
+ (* eq_trans : forall x y z : T, x = y -> y = z -> x = z; *)
  eq_dec : forall x y : T, { x = y } + { x <> y }
 }.
 
 
-Hint Immediate eq_sym.
-Hint Resolve eq_refl eq_trans.
+(* Hint Immediate eq_sym. *)
+(* Hint Resolve eq_refl eq_trans. *)
 
 (** Types equipped with Boolean equality are decidable *)
-Instance EqbToDecType T `(EqbType T) : DecType T.
-Proof.
-  destruct H.
-  split; auto.
-  intros; subst; auto.
-  apply (eqb_to_eq_dec _ eqb0); auto.
-Defined.
+Section EqbToDecType.
+  Generalizable Variable T.
+  Context `{ET : EqbType T}.
+
+  Instance EqbToDecType : DecType T.
+  Proof.
+    destruct ET as [eqb0 Heqb0]. split.
+    apply (eqb_to_eq_dec _ eqb0); auto.
+  Defined.
+End EqbToDecType.
 
 
 (** Class of types with a partial order *)
 Class OrdType T := {
   lt: T -> T -> Prop;
   lt_trans : forall x y z : T, lt x y -> lt y z -> lt x z;
-  lt_not_eq : forall x y : T, lt x y -> ~ eq x y
-  (* compare : forall x y : T, Compare lt eq x y *)
+  lt_not_eq : forall x y : T, lt x y -> x <> y
 }.
 
 Hint Resolve lt_not_eq lt_trans.
@@ -84,6 +86,29 @@ Class Comparable T {ot:OrdType T} := {
 }.
 
 
+(* A Comparable type is also an EqbType *)
+Section Comparable2EqbType.
+  Generalizable Variable T.
+  Context `{OTT : OrdType T}.
+  Context `{CT : Comparable T}.
+
+  Definition compare2eqb (x y:T) : bool :=
+    match compare x y with
+    | EQ _ => true
+    | _ => false
+    end.
+
+  Lemma compare2eqb_spec x y : compare2eqb x y = true <-> x = y.
+  Proof.
+    unfold compare2eqb.
+    case_eq (compare x y); simpl; intros e He; split; try discriminate;
+      try (intros ->; elim (lt_not_eq _ _ e (eq_refl _))); auto.
+  Qed.
+
+  Instance Comparable2EqbType : EqbType T := Build_EqbType _ _ compare2eqb_spec.
+End Comparable2EqbType.
+
+
 (** Class of inhabited types *)
 Class Inhabited T := {
   default_value : T
@@ -92,45 +117,46 @@ Class Inhabited T := {
 (** * CompDec: Merging all previous classes *)
 
 Class CompDec T := {
-  ty := T;
-  Eqb :> EqbType ty;
-  Decidable := EqbToDecType ty Eqb;
-  Ordered :> OrdType ty;       
-  Comp :> @Comparable ty Ordered;
-  Inh :> Inhabited ty
+  (* ty := T; *)
+  (* Eqb :> EqbType T; *)
+  (* Decidable := EqbToDecType ty Eqb; *)
+  Ordered :> OrdType T;
+  Comp :> @Comparable T Ordered;
+  Inh :> Inhabited T
 }.
 
 
 Instance ord_of_compdec t `{c: CompDec t} : (OrdType t) := 
-  let (_, _, _, ord, _, _) := c in ord.
+  let (ord, _, _) := c in ord.
+  (* let (_, _, _, ord, _, _) := c in ord. *)
 
-Instance inh_of_compdec t `{c: CompDec t} : (Inhabited t) := 
-  let (_, _, _, _, _, inh) := c in inh.
+Instance inh_of_compdec t `{c: CompDec t} : (Inhabited t) :=
+  let (_, _, inh) := c in inh.
 
 Instance comp_of_compdec t `{c: CompDec t} : @Comparable t (ord_of_compdec t).
-destruct c; trivial.
+  destruct c; trivial.
 Defined.
 
-Instance eqbtype_of_compdec t `{c: CompDec t} : EqbType t :=
-  let (_, eqbtype, _, _, _, inh) := c in eqbtype.
+Instance eqbtype_of_compdec t `{c: CompDec t} : EqbType t := Comparable2EqbType.
+  (* let (_, eqbtype, _, _, _, inh) := c in eqbtype. *)
 
-Instance dec_of_compdec t `{c: CompDec t} : DecType t :=
-  let (_, _, dec, _, _, inh) := c in dec.
+(* Instance dec_of_compdec t `{c: CompDec t} : DecType t := *)
+(*   let (_, _, dec, _, _, inh) := c in dec. *)
 
 
-Definition type_compdec {ty:Type} (cd : CompDec ty) := ty.
+(* Definition type_compdec {ty:Type} (cd : CompDec ty) := ty. *)
 
 Definition eqb_of_compdec {t} (c : CompDec t) : t -> t -> bool :=
-  match c with
-  | {| ty := ty; Eqb := {| eqb := eqb |} |} => eqb
+  match eqbtype_of_compdec t with
+  | {| eqb := eqb |} => eqb
   end.
 
 
 Lemma compdec_eq_eqb {T:Type} {c : CompDec T} : forall x y : T,
     x = y <-> eqb_of_compdec c x y = true.
 Proof.
-  destruct c. destruct Eqb0.
-  simpl. intros. rewrite eqb_spec0. reflexivity.
+  intros x y. unfold eqb_of_compdec, eqbtype_of_compdec, Comparable2EqbType.
+  now rewrite compare2eqb_spec.
 Qed.
 
 Hint Resolve
@@ -138,7 +164,7 @@ Hint Resolve
      inh_of_compdec
      comp_of_compdec
      eqbtype_of_compdec
-     dec_of_compdec : typeclass_instances.
+     (* dec_of_compdec *) : typeclass_instances.
 
 
 Record typ_compdec : Type := Typ_compdec {
@@ -146,28 +172,28 @@ Record typ_compdec : Type := Typ_compdec {
   te_compdec : CompDec te_carrier
 }.
 
-Section CompDec_from.
+(* Section CompDec_from. *)
 
-  Variable T : Type.
-  Variable eqb' : T -> T -> bool.
-  Variable lt' : T -> T -> Prop.
-  Variable d : T.
+(*   Variable T : Type. *)
+(*   Variable eqb' : T -> T -> bool. *)
+(*   Variable lt' : T -> T -> Prop. *)
+(*   (* Variable d : T. *) *)
 
-  Hypothesis eqb_spec' : forall x y : T, eqb' x y = true <-> x = y.
-  Hypothesis lt_trans': forall x y z : T, lt' x y -> lt' y z -> lt' x z.
-  Hypothesis lt_neq': forall x y : T, lt' x y -> x <> y.
+(*   Hypothesis eqb_spec' : forall x y : T, eqb' x y = true <-> x = y. *)
+(*   Hypothesis lt_trans': forall x y z : T, lt' x y -> lt' y z -> lt' x z. *)
+(*   Hypothesis lt_neq': forall x y : T, lt' x y -> x <> y. *)
   
-  Variable compare': forall x y : T, Compare lt' eq x y.
+(*   Variable compare': forall x y : T, Compare lt' eq x y. *)
   
-  Program Instance CompDec_from : (CompDec T) := {|
-    Eqb := {| eqb := eqb' |};
-    Ordered := {| lt := lt'; lt_trans := lt_trans' |};
-    Comp := {| compare := compare' |};
-    Inh := {| default_value := d |}
-  |}.
+(*   Program Instance CompDec_from : (CompDec T) := {| *)
+(*     Eqb := {| eqb := eqb' |}; *)
+(*     Ordered := {| lt := lt'; lt_trans := lt_trans' |}; *)
+(*     Comp := {| compare := compare' |} *)
+(*     (* Inh := {| default_value := d |} *) *)
+(*   |}. *)
 
   
-  Definition typ_compdec_from : typ_compdec :=
-    Typ_compdec T CompDec_from.
+(*   Definition typ_compdec_from : typ_compdec := *)
+(*     Typ_compdec T CompDec_from. *)
   
-End CompDec_from.
+(* End CompDec_from. *)

--- a/src/classes/SMT_classes_instances.v
+++ b/src/classes/SMT_classes_instances.v
@@ -22,25 +22,25 @@ Section Unit.
 
   Let lt : unit -> unit -> Prop := fun _ _ => False.
 
-  Instance unit_ord : OrdType unit.
+  Global Instance unit_ord : OrdType unit.
   Proof. exists lt; unfold lt; trivial.
     intros; contradict H; trivial.
   Defined.
 
-  Instance unit_eqbtype : EqbType unit.
+  Global Instance unit_eqbtype : EqbType unit.
   Proof.
     exists eqb. intros. destruct x, y. unfold eqb. split; trivial.
   Defined.
 
-  Instance unit_comp : @Comparable unit unit_ord.
+  Global Instance unit_comp : @Comparable unit unit_ord.
   Proof.
     split. intros. destruct x, y.
     apply OrderedType.EQ; trivial.
   Defined.
 
-  Instance unit_inh : Inhabited unit := {| default_value := tt |}.
+  Global Instance unit_inh : Inhabited unit := {| default_value := tt |}.
 
-  Instance unit_compdec : CompDec unit := {|
+  Global Instance unit_compdec : CompDec unit := {|
     Eqb := unit_eqbtype;
     Ordered := unit_ord;
     Comp := unit_comp;
@@ -58,7 +58,7 @@ Section Bool.
 
   Definition lt_bool x y := ltb_bool x y = true.
 
-  Instance bool_ord : OrdType bool.
+  Global Instance bool_ord : OrdType bool.
   Proof.
     exists lt_bool.
     intros x y z.
@@ -67,7 +67,7 @@ Section Bool.
     case x; case y; intros; simpl in H; easy.
   Defined.
 
-  Instance bool_comp: Comparable bool.
+  Global Instance bool_comp: Comparable bool.
   Proof.
     constructor.
     intros x y.
@@ -85,14 +85,14 @@ Section Bool.
     case x in *; case y in *; auto.
   Defined.
 
-  Instance bool_eqbtype : EqbType bool :=
+  Global Instance bool_eqbtype : EqbType bool :=
     {| eqb := Bool.eqb; eqb_spec := eqb_true_iff |}.
 
-  Instance bool_dec : DecType bool := EqbToDecType.
+  Global Instance bool_dec : DecType bool := EqbToDecType.
 
-  Instance bool_inh : Inhabited bool := {| default_value := false|}.
+  Global Instance bool_inh : Inhabited bool := {| default_value := false|}.
 
-  Instance bool_compdec : CompDec bool := {|
+  Global Instance bool_compdec : CompDec bool := {|
     Eqb := bool_eqbtype;
     Ordered := bool_ord;
     Comp := bool_comp;
@@ -110,7 +110,7 @@ End Bool.
 
 Section Z.
 
-  Instance Z_ord : OrdType Z.
+  Global Instance Z_ord : OrdType Z.
   Proof.
     exists Z_as_OT.lt.
     exact Z_as_OT.lt_trans.
@@ -118,22 +118,22 @@ Section Z.
   Defined.
 
 
-  Instance Z_comp: Comparable Z.
+  Global Instance Z_comp: Comparable Z.
   Proof.
     constructor.
     apply Z_as_OT.compare.
   Defined.
 
-  Instance Z_eqbtype : EqbType Z :=
+  Global Instance Z_eqbtype : EqbType Z :=
     {| eqb := Z.eqb; eqb_spec := Z.eqb_eq |}.
 
-  Instance Z_dec : DecType Z := EqbToDecType.
+  Global Instance Z_dec : DecType Z := @EqbToDecType _ Z_eqbtype.
 
 
-  Instance Z_inh : Inhabited Z := {| default_value := 0%Z |}.
+  Global Instance Z_inh : Inhabited Z := {| default_value := 0%Z |}.
 
 
-  Instance Z_compdec : CompDec Z := {|
+  Global Instance Z_compdec : CompDec Z := {|
     Eqb := Z_eqbtype;
     Ordered := Z_ord;
     Comp := Z_comp;
@@ -237,7 +237,7 @@ End Z.
 
 Section Nat.
 
-  Instance Nat_ord : OrdType nat.
+  Global Instance Nat_ord : OrdType nat.
   Proof.
 
     exists Nat_as_OT.lt.
@@ -246,22 +246,22 @@ Section Nat.
   Defined.
 
 
-  Instance Nat_comp: Comparable nat.
+  Global Instance Nat_comp: Comparable nat.
   Proof.
     constructor.
     apply Nat_as_OT.compare.
   Defined.
 
-  Instance Nat_eqbtype : EqbType nat :=
+  Global Instance Nat_eqbtype : EqbType nat :=
     {| eqb := Structures.nat_eqb; eqb_spec := Structures.nat_eqb_eq |}.
 
-  Instance Nat_dec : DecType nat := EqbToDecType.
+  Global Instance Nat_dec : DecType nat := EqbToDecType.
 
 
-  Instance Nat_inh : Inhabited nat := {| default_value := O%nat |}.
+  Global Instance Nat_inh : Inhabited nat := {| default_value := O%nat |}.
 
 
-  Instance Nat_compdec : CompDec nat := {|
+  Global Instance Nat_compdec : CompDec nat := {|
     Eqb := Nat_eqbtype;
     Ordered := Nat_ord;
     Comp := Nat_comp;
@@ -273,27 +273,27 @@ End Nat.
 
 Section Positive.
 
-  Instance Positive_ord : OrdType positive.
+  Global Instance Positive_ord : OrdType positive.
   Proof.
     exists Positive_as_OT.lt.
     exact Positive_as_OT.lt_trans.
     exact Positive_as_OT.lt_not_eq.
   Defined.
 
-  Instance Positive_comp: Comparable positive.
+  Global Instance Positive_comp: Comparable positive.
   Proof.
     constructor.
     apply Positive_as_OT.compare.
   Defined.
 
-  Instance Positive_eqbtype : EqbType positive :=
+  Global Instance Positive_eqbtype : EqbType positive :=
     {| eqb := Pos.eqb; eqb_spec := Pos.eqb_eq |}.
 
-  Instance Positive_dec : DecType positive := EqbToDecType.
+  Global Instance Positive_dec : DecType positive := EqbToDecType.
 
-  Instance Positive_inh : Inhabited positive := {| default_value := 1%positive |}.
+  Global Instance Positive_inh : Inhabited positive := {| default_value := 1%positive |}.
 
-  Instance Positive_compdec : CompDec positive := {|
+  Global Instance Positive_compdec : CompDec positive := {|
     Eqb := Positive_eqbtype;
     Ordered := Positive_ord;
     Comp := Positive_comp;
@@ -309,7 +309,7 @@ Section BV.
   Import BITVECTOR_LIST.
 
 
-  Instance BV_ord n : OrdType (bitvector n).
+  Global Instance BV_ord n : OrdType (bitvector n).
   Proof.
     exists (fun a b => (bv_ult a b)).
     unfold bv_ult, RAWBITVECTOR_LIST.bv_ult.
@@ -328,7 +328,7 @@ Section BV.
   Defined.
 
 
-  Instance BV_comp n: Comparable (bitvector n).
+  Global Instance BV_comp n: Comparable (bitvector n).
   Proof.
     constructor.
     intros x y.
@@ -366,17 +366,17 @@ Section BV.
     now apply RAWBITVECTOR_LIST.rev_neq in H.
   Defined.
 
-  Instance BV_eqbtype n : EqbType (bitvector n) :=
+  Global Instance BV_eqbtype n : EqbType (bitvector n) :=
     {| eqb := @bv_eq n;
        eqb_spec := @bv_eq_reflect n |}.
 
-  Instance BV_dec n : DecType (bitvector n) := EqbToDecType.
+  Global Instance BV_dec n : DecType (bitvector n) := EqbToDecType.
 
-  Instance BV_inh n : Inhabited (bitvector n) :=
+  Global Instance BV_inh n : Inhabited (bitvector n) :=
     {| default_value := zeros n |}.
 
 
-  Instance BV_compdec n: CompDec (bitvector n) := {|
+  Global Instance BV_compdec n: CompDec (bitvector n) := {|
     Eqb := BV_eqbtype n;
     Ordered := BV_ord n;
     Comp := BV_comp n;
@@ -389,7 +389,7 @@ End BV.
 
 Section FArray.
 
-  Instance FArray_ord key elt
+  Global Instance FArray_ord key elt
            `{key_ord: OrdType key}
            `{elt_ord: OrdType elt}
            `{elt_inh: Inhabited elt}
@@ -406,7 +406,7 @@ Section FArray.
   Defined.
 
 
-  Instance FArray_comp key elt
+  Global Instance FArray_comp key elt
            `{key_ord: OrdType key}
            `{elt_ord: OrdType elt}
            `{key_comp: @Comparable key key_ord}
@@ -425,7 +425,7 @@ Section FArray.
     - apply OrderedType.GT. auto.
   Defined.
 
-  Instance FArray_eqbtype key elt
+  Global Instance FArray_eqbtype key elt
            `{key_ord: OrdType key}
            `{elt_ord: OrdType elt}
            `{elt_eqbtype: EqbType elt}
@@ -441,7 +441,7 @@ Section FArray.
     intros. subst. apply eq_equal. apply eqfarray_refl.
   Defined.
 
-  Instance FArray_dec key elt
+  Global Instance FArray_dec key elt
            `{key_ord: OrdType key}
            `{elt_ord: OrdType elt}
            `{elt_eqbtype: EqbType elt}
@@ -450,13 +450,13 @@ Section FArray.
            `{elt_inh: Inhabited elt}
     : DecType (farray key elt) := EqbToDecType.
 
-  Instance FArray_inh key elt
+  Global Instance FArray_inh key elt
            `{key_ord: OrdType key}
            `{elt_inh: Inhabited elt} : Inhabited (farray key elt) :=
     {| default_value := FArray.empty key_ord elt_inh |}.
 
 
-  Program Instance FArray_compdec key elt
+  Global Instance FArray_compdec key elt
           `{key_compdec: CompDec key}
           `{elt_compdec: CompDec elt} :
     CompDec (farray key elt) :=
@@ -477,7 +477,7 @@ Section Int63.
   Let int_lt x y :=
     if Int63Native.ltb x y then True else False.
 
-  Instance int63_ord : OrdType int.
+  Global Instance int63_ord : OrdType int.
   Proof.
     exists int_lt; unfold int_lt.
     - intros x y z.
@@ -498,7 +498,7 @@ Section Int63.
   Defined.
 
 
-  Instance int63_comp: Comparable int.
+  Global Instance int63_comp: Comparable int.
   Proof.
     constructor.
     intros x y.
@@ -523,15 +523,15 @@ Section Int63.
       rewrite H0. auto.
   Defined.
 
-  Instance int63_eqbtype : EqbType int :=
+  Global Instance int63_eqbtype : EqbType int :=
     {| eqb := Int63Native.eqb; eqb_spec := Int63Properties.eqb_spec |}.
 
-  Instance int63_dec : DecType int := EqbToDecType.
+  Global Instance int63_dec : DecType int := EqbToDecType.
 
 
-  Instance int63_inh : Inhabited int := {| default_value := 0 |}.
+  Global Instance int63_inh : Inhabited int := {| default_value := 0 |}.
 
-  Instance int63_compdec : CompDec int := {|
+  Global Instance int63_compdec : CompDec int := {|
     Eqb := int63_eqbtype;
     Ordered := int63_ord;
     Comp := int63_comp;
@@ -573,7 +573,7 @@ Section option.
   Qed.
 
 
-  Instance option_ord : OrdType (option A) :=
+  Global Instance option_ord : OrdType (option A) :=
     Build_OrdType _ _ option_lt_trans option_lt_not_eq.
 
 
@@ -589,15 +589,15 @@ Section option.
     - now apply EQ.
   Defined.
 
-  Instance option_comp : Comparable (option A) := Build_Comparable _ _ option_compare.
+  Global Instance option_comp : Comparable (option A) := Build_Comparable _ _ option_compare.
 
-  Instance option_eqbtype : EqbType (option A) := Comparable2EqbType.
-
-
-  Instance option_inh : Inhabited (option A) := Build_Inhabited _ None.
+  Global Instance option_eqbtype : EqbType (option A) := Comparable2EqbType.
 
 
-  Instance option_compdec : CompDec (option A) := {|
+  Global Instance option_inh : Inhabited (option A) := Build_Inhabited _ None.
+
+
+  Global Instance option_compdec : CompDec (option A) := {|
     Ordered := option_ord;
     Comp := option_comp;
     Inh := option_inh
@@ -662,19 +662,19 @@ Section list.
   Qed.
 
 
-  Instance list_ord : OrdType (list A) :=
+  Global Instance list_ord : OrdType (list A) :=
     Build_OrdType _ _ list_lt_trans list_lt_not_eq.
 
 
-  Instance list_comp : Comparable (list A) := Build_Comparable _ _ list_compare.
+  Global Instance list_comp : Comparable (list A) := Build_Comparable _ _ list_compare.
 
-  Instance list_eqbtype : EqbType (list A) := Comparable2EqbType.
-
-
-  Instance list_inh : Inhabited (list A) := Build_Inhabited _ nil.
+  Global Instance list_eqbtype : EqbType (list A) := Comparable2EqbType.
 
 
-  Instance list_compdec : CompDec (list A) := {|
+  Global Instance list_inh : Inhabited (list A) := Build_Inhabited _ nil.
+
+
+  Global Instance list_compdec : CompDec (list A) := {|
     Ordered := list_ord;
     Comp := list_comp;
     Inh := list_inh

--- a/src/classes/SMT_classes_instances.v
+++ b/src/classes/SMT_classes_instances.v
@@ -19,18 +19,11 @@ Require Export SMT_classes.
 
 Section Unit.
 
-  Let eqb : unit -> unit -> bool := fun _ _ => true.
-
   Let lt : unit -> unit -> Prop := fun _ _ => False.
-  
+
   Instance unit_ord : OrdType unit.
   Proof. exists lt; unfold lt; trivial.
     intros; contradict H; trivial.
-  Defined.
-
-  Instance unit_eqbtype : EqbType unit.
-  Proof.
-    exists eqb. intros. destruct x, y. unfold eqb. split; trivial.
   Defined.
 
   Instance unit_comp : @Comparable unit unit_ord.
@@ -39,24 +32,18 @@ Section Unit.
     apply OrderedType.EQ; trivial.
   Defined.
 
+  Instance unit_eqbtype : EqbType unit := Comparable2EqbType.
+
   Instance unit_inh : Inhabited unit := {| default_value := tt |}.
-  
+
   Instance unit_compdec : CompDec unit := {|
-    Eqb := unit_eqbtype;
     Ordered := unit_ord;
     Comp := unit_comp;
     Inh := unit_inh
   |}.
 
-
-  
   Definition unit_typ_compdec := Typ_compdec unit unit_compdec.
 
-
-  Lemma eqb_eq_unit : forall x y, eqb x y <-> x = y.
-  Proof. intros. split; case x; case y; unfold eqb; intros; now auto.
-  Qed.
-  
 End Unit.
 
 
@@ -65,21 +52,15 @@ Section Bool.
   Definition ltb_bool x y := negb x && y.
 
   Definition lt_bool x y := ltb_bool x y = true.
-  
+
   Instance bool_ord : OrdType bool.
   Proof.
     exists lt_bool.
     intros x y z.
-    case x; case y; case z; intros; simpl; subst; auto. 
+    case x; case y; case z; intros; simpl; subst; auto.
     intros x y.
-    case x; case y; intros; simpl in H; easy. 
+    case x; case y; intros; simpl in H; easy.
   Defined.
-
-  Instance bool_eqbtype : EqbType bool :=
-    {| eqb := Bool.eqb; eqb_spec := eqb_true_iff |}.
-  
-  Instance bool_dec : DecType bool :=
-    EqbToDecType _ bool_eqbtype.
 
   Instance bool_comp: Comparable bool.
   Proof.
@@ -99,11 +80,14 @@ Section Bool.
     case x in *; case y in *; auto.
   Defined.
 
+  Instance bool_eqbtype : EqbType bool := Comparable2EqbType.
+
+  Instance bool_dec : DecType bool := EqbToDecType.
+
   Instance bool_inh : Inhabited bool := {| default_value := false|}.
 
   Instance bool_compdec : CompDec bool := {|
-    Eqb := bool_eqbtype;                                    
-    Ordered := bool_ord;                                    
+    Ordered := bool_ord;
     Comp := bool_comp;
     Inh := bool_inh
   |}.
@@ -126,29 +110,23 @@ Section Z.
     exact Z_as_OT.lt_not_eq.
   Defined.
 
-  Instance Z_eqbtype : EqbType Z :=
-    {| eqb := Z.eqb; eqb_spec := Z.eqb_eq |}.
 
-  (* Instance Z_eqbtype : EqbType Z := *)
-  (*   {| eqb := Zeq_bool; eqb_spec := fun x y => symmetry (Zeq_is_eq_bool x y) |}. *)
-  
-  Instance Z_dec : DecType Z :=
-    EqbToDecType _ Z_eqbtype.
-
-  
   Instance Z_comp: Comparable Z.
   Proof.
     constructor.
     apply Z_as_OT.compare.
   Defined.
 
+  Instance Z_eqbtype : EqbType Z := Comparable2EqbType.
+
+  Instance Z_dec : DecType Z := EqbToDecType.
+
 
   Instance Z_inh : Inhabited Z := {| default_value := 0%Z |}.
 
-    
+
   Instance Z_compdec : CompDec Z := {|
-    Eqb := Z_eqbtype;                                    
-    Ordered := Z_ord;                                    
+    Ordered := Z_ord;
     Comp := Z_comp;
     Inh := Z_inh
   |}.
@@ -202,7 +180,7 @@ Section Z.
 
   Lemma lt_Z_B2P': forall x y, ltP_Z x y <-> Z.lt x y.
   Proof. intros x y; split; intro H.
-         unfold ltP_Z in H. 
+         unfold ltP_Z in H.
          case_eq ((x <? y)%Z ); intros; rewrite H0 in H; try easy.
          now apply Z.ltb_lt in H0.
          apply lt_Z_B2P.
@@ -211,7 +189,7 @@ Section Z.
 
   Lemma le_Z_B2P': forall x y, leP_Z x y <-> Z.le x y.
   Proof. intros x y; split; intro H.
-         unfold leP_Z in H. 
+         unfold leP_Z in H.
          case_eq ((x <=? y)%Z ); intros; rewrite H0 in H; try easy.
          now apply Z.leb_le in H0.
          apply le_Z_B2P.
@@ -220,7 +198,7 @@ Section Z.
 
   Lemma gt_Z_B2P': forall x y, gtP_Z x y <-> Z.gt x y.
   Proof. intros x y; split; intro H.
-         unfold gtP_Z in H. 
+         unfold gtP_Z in H.
          case_eq ((x >? y)%Z ); intros; rewrite H0 in H; try easy.
          now apply Zgt_is_gt_bool in H0.
          apply gt_Z_B2P.
@@ -229,7 +207,7 @@ Section Z.
 
   Lemma ge_Z_B2P': forall x y, geP_Z x y <-> Z.ge x y.
   Proof. intros x y; split; intro H.
-         unfold geP_Z in H. 
+         unfold geP_Z in H.
          case_eq ((x >=? y)%Z ); intros; rewrite H0 in H; try easy.
          rewrite Z.geb_leb in H0. rewrite le_Z_B2P in H0.
          apply le_Z_B2P' in H0. now apply Z.ge_le_iff.
@@ -252,32 +230,29 @@ Section Nat.
 
   Instance Nat_ord : OrdType nat.
   Proof.
-    
+
     exists Nat_as_OT.lt.
     exact Nat_as_OT.lt_trans.
     exact Nat_as_OT.lt_not_eq.
   Defined.
 
-  Instance Nat_eqbtype : EqbType nat :=
-    {| eqb := Structures.nat_eqb; eqb_spec := Structures.nat_eqb_eq |}.
-  
-  Instance Nat_dec : DecType nat :=
-    EqbToDecType _ Nat_eqbtype.
 
-  
   Instance Nat_comp: Comparable nat.
   Proof.
     constructor.
     apply Nat_as_OT.compare.
   Defined.
 
+  Instance Nat_eqbtype : EqbType nat := Comparable2EqbType.
+
+  Instance Nat_dec : DecType nat := EqbToDecType.
+
 
   Instance Nat_inh : Inhabited nat := {| default_value := O%nat |}.
 
-    
+
   Instance Nat_compdec : CompDec nat := {|
-    Eqb := Nat_eqbtype;                                    
-    Ordered := Nat_ord;                                    
+    Ordered := Nat_ord;
     Comp := Nat_comp;
     Inh := Nat_inh
   |}.
@@ -294,23 +269,20 @@ Section Positive.
     exact Positive_as_OT.lt_not_eq.
   Defined.
 
-  Instance Positive_eqbtype : EqbType positive :=
-    {| eqb := Pos.eqb; eqb_spec := Pos.eqb_eq |}.
-  
-  Instance Positive_dec : DecType positive :=
-    EqbToDecType _ Positive_eqbtype.
-
   Instance Positive_comp: Comparable positive.
   Proof.
     constructor.
     apply Positive_as_OT.compare.
   Defined.
 
+  Instance Positive_eqbtype : EqbType positive := Comparable2EqbType.
+
+  Instance Positive_dec : DecType positive := EqbToDecType.
+
   Instance Positive_inh : Inhabited positive := {| default_value := 1%positive |}.
 
   Instance Positive_compdec : CompDec positive := {|
-    Eqb := Positive_eqbtype;                                    
-    Ordered := Positive_ord;                                    
+    Ordered := Positive_ord;
     Comp := Positive_comp;
     Inh := Positive_inh
   |}.
@@ -323,7 +295,7 @@ Section BV.
 
   Import BITVECTOR_LIST.
 
-  
+
   Instance BV_ord n : OrdType (bitvector n).
   Proof.
     exists (fun a b => (bv_ult a b)).
@@ -342,14 +314,7 @@ Section BV.
     apply H. easy.
   Defined.
 
-  Instance BV_eqbtype n : EqbType (bitvector n) :=
-    {| eqb := @bv_eq n;
-       eqb_spec := @bv_eq_reflect n |}.
 
-  Instance BV_dec n : DecType (bitvector n) :=
-    EqbToDecType _ (BV_eqbtype n).
-
-  
   Instance BV_comp n: Comparable (bitvector n).
   Proof.
     constructor.
@@ -388,13 +353,16 @@ Section BV.
     now apply RAWBITVECTOR_LIST.rev_neq in H.
   Defined.
 
+  Instance BV_eqbtype n : EqbType (bitvector n) := Comparable2EqbType.
+
+  Instance BV_dec n : DecType (bitvector n) := EqbToDecType.
+
   Instance BV_inh n : Inhabited (bitvector n) :=
     {| default_value := zeros n |}.
 
 
   Instance BV_compdec n: CompDec (bitvector n) := {|
-    Eqb := BV_eqbtype n;                                    
-    Ordered := BV_ord n;                                    
+    Ordered := BV_ord n;
     Comp := BV_comp n;
     Inh := BV_inh n
   |}.
@@ -408,7 +376,6 @@ Section FArray.
   Instance FArray_ord key elt
            `{key_ord: OrdType key}
            `{elt_ord: OrdType elt}
-           `{elt_dec: DecType elt}
            `{elt_inh: Inhabited elt}
            `{key_comp: @Comparable key key_ord} : OrdType (farray key elt).
   Proof.
@@ -419,49 +386,20 @@ Section FArray.
     apply lt_farray_not_eq in H.
     apply H.
     rewrite H0.
-    apply eqfarray_refl. auto.
+    apply eqfarray_refl.
   Defined.
 
-  Instance FArray_eqbtype key elt
-           `{key_ord: OrdType key}
-           `{elt_ord: OrdType elt}
-           `{elt_eqbtype: EqbType elt}
-           `{key_comp: @Comparable key key_ord}
-           `{elt_comp: @Comparable elt elt_ord}
-           `{elt_inh: Inhabited elt}
-    : EqbType (farray key elt).
-  Proof.
-    exists FArray.equal.
-    intros.
-    split.
-    apply FArray.equal_eq.
-    intros. subst. apply eq_equal. apply eqfarray_refl.
-    apply EqbToDecType. auto.
-  Defined.
 
-  
-  Instance FArray_dec key elt
-           `{key_ord: OrdType key}
-           `{elt_ord: OrdType elt}
-           `{elt_eqbtype: EqbType elt}
-           `{key_comp: @Comparable key key_ord}
-           `{elt_comp: @Comparable elt elt_ord}
-           `{elt_inh: Inhabited elt}
-    : DecType (farray key elt) :=
-    EqbToDecType _ (FArray_eqbtype key elt).
-
-  
   Instance FArray_comp key elt
            `{key_ord: OrdType key}
            `{elt_ord: OrdType elt}
-           `{elt_eqbtype: EqbType elt}
            `{key_comp: @Comparable key key_ord}
            `{elt_inh: Inhabited elt}
            `{elt_comp: @Comparable elt elt_ord} : Comparable (farray key elt).
   Proof.
     constructor.
     intros.
-    destruct (compare_farray key_comp (EqbToDecType _ elt_eqbtype) elt_comp x y).
+    destruct (compare_farray key_comp elt_comp x y).
     - apply OrderedType.LT. auto.
     - apply OrderedType.EQ.
       specialize (@eq_equal key elt key_ord key_comp elt_ord elt_comp elt_inh x y).
@@ -470,6 +408,23 @@ Section FArray.
       now apply equal_eq in e.
     - apply OrderedType.GT. auto.
   Defined.
+
+  Instance FArray_eqbtype key elt
+           `{key_ord: OrdType key}
+           `{elt_ord: OrdType elt}
+           `{key_comp: @Comparable key key_ord}
+           `{elt_comp: @Comparable elt elt_ord}
+           `{elt_inh: Inhabited elt}
+    : EqbType (farray key elt) := Comparable2EqbType.
+
+
+  Instance FArray_dec key elt
+           `{key_ord: OrdType key}
+           `{elt_ord: OrdType elt}
+           `{key_comp: @Comparable key key_ord}
+           `{elt_comp: @Comparable elt elt_ord}
+           `{elt_inh: Inhabited elt}
+    : DecType (farray key elt) := EqbToDecType.
 
   Instance FArray_inh key elt
            `{key_ord: OrdType key}
@@ -482,42 +437,25 @@ Section FArray.
           `{elt_compdec: CompDec elt} :
     CompDec (farray key elt) :=
     {|
-      Eqb := FArray_eqbtype key elt;
       Ordered := FArray_ord key elt;
-      (*  Comp := FArray_comp key elt ; *)
+      Comp := FArray_comp key elt ;
       Inh := FArray_inh key elt
     |}.
-  
-  Next Obligation.
-    constructor.
-    destruct key_compdec, elt_compdec.
-    simpl in *.
-    unfold lt_farray.
-    intros. simpl.
-    unfold EqbToDecType. simpl.
-    case_eq (compare x y); intros.
-    apply OrderedType.LT.
-    destruct (compare x y); try discriminate H; auto.
-    apply OrderedType.EQ.
-    destruct (compare x y); try discriminate H; auto.
-    apply OrderedType.GT.
-    destruct (compare y x); try discriminate H; auto; clear H.
-  Defined.
 
 End FArray.
 
 
 Section Int63.
-  
+
   Local Open Scope int63_scope.
 
   Let int_lt x y :=
     if Int63Native.ltb x y then True else False.
-  
+
   Instance int63_ord : OrdType int.
   Proof.
     exists int_lt; unfold int_lt.
-    - intros x y z. 
+    - intros x y z.
       case_eq (x < y); intro;
         case_eq (y < z); intro;
           case_eq (x < z); intro;
@@ -533,12 +471,6 @@ Section Int63.
       rewrite <- Int63Properties.to_Z_eq.
       exact (Z.lt_neq _ _ H).
   Defined.
-  
-  Instance int63_eqbtype : EqbType int :=
-    {| eqb := Int63Native.eqb; eqb_spec := Int63Properties.eqb_spec |}.
-
-  Instance int63_dec : DecType int :=
-    EqbToDecType _ int63_eqbtype.
 
 
   Instance int63_comp: Comparable int.
@@ -566,16 +498,19 @@ Section Int63.
       rewrite H0. auto.
   Defined.
 
+  Instance int63_eqbtype : EqbType int := Comparable2EqbType.
+
+  Instance int63_dec : DecType int := EqbToDecType.
+
 
   Instance int63_inh : Inhabited int := {| default_value := 0 |}.
-    
+
   Instance int63_compdec : CompDec int := {|
-    Eqb := int63_eqbtype;                                    
-    Ordered := int63_ord;                                    
+    Ordered := int63_ord;
     Comp := int63_comp;
     Inh := int63_inh
   |}.
-         
+
 
 End Int63.
 
@@ -584,25 +519,6 @@ Section option.
 
   Generalizable Variable A.
   Context `{HA : CompDec A}.
-
-
-  Definition option_eqb (x y : option A) : bool :=
-    match x, y with
-    | Some a, Some b => eqb a b
-    | None, None => true
-    | _, _ => false
-    end.
-
-
-  Lemma option_eqb_spec : forall (x y : option A), option_eqb x y = true <-> x = y.
-  Proof.
-    intros [a| ] [b| ]; simpl; split; try discriminate; auto.
-    - intro H. rewrite eqb_spec in H. now subst b.
-    - intros H. inversion H as [H1]. now rewrite eqb_spec.
-  Qed.
-
-
-  Instance option_eqbtype : EqbType (option A) := Build_EqbType _ _ option_eqb_spec.
 
 
   Definition option_lt (x y : option A) : Prop :=
@@ -647,15 +563,15 @@ Section option.
     - now apply EQ.
   Defined.
 
-
   Instance option_comp : Comparable (option A) := Build_Comparable _ _ option_compare.
+
+  Instance option_eqbtype : EqbType (option A) := Comparable2EqbType.
 
 
   Instance option_inh : Inhabited (option A) := Build_Inhabited _ None.
 
 
   Instance option_compdec : CompDec (option A) := {|
-    Eqb := option_eqbtype;
     Ordered := option_ord;
     Comp := option_comp;
     Inh := option_inh
@@ -670,27 +586,6 @@ Section list.
   Context `{HA : CompDec A}.
 
 
-  Fixpoint list_eqb (xs ys : list A) : bool :=
-    match xs, ys with
-    | nil, nil => true
-    | x::xs, y::ys => eqb x y && list_eqb xs ys
-    | _, _ => false
-    end.
-
-
-  Lemma list_eqb_spec : forall (x y : list A), list_eqb x y = true <-> x = y.
-  Proof.
-    induction x as [ |x xs IHxs]; intros [ |y ys]; simpl; split; try discriminate; auto.
-    - rewrite andb_true_iff. intros [H1 H2]. rewrite eqb_spec in H1. rewrite IHxs in H2. now subst.
-    - intros H. inversion H as [H1]. rewrite andb_true_iff; split.
-      + now rewrite eqb_spec.
-      + subst ys. now rewrite IHxs.
-  Qed.
-
-
-  Instance list_eqbtype : EqbType (list A) := Build_EqbType _ _ list_eqb_spec.
-
-
   Fixpoint list_lt (xs ys : list A) : Prop :=
     match xs, ys with
     | nil, nil => False
@@ -698,35 +593,6 @@ Section list.
     | _::_, nil => False
     | x::xs, y::ys => (lt x y) \/ (eqb x y /\ list_lt xs ys)
     end.
-
-
-  Lemma list_lt_trans : forall (x y z : list A),
-      list_lt x y -> list_lt y z -> list_lt x z.
-  Proof.
-    induction x as [ |x xs IHxs]; intros [ |y ys] [ |z zs]; simpl; auto.
-    - inversion 1.
-    - intros [H1|[H1a H1b]] [H2|[H2a H2b]].
-      + left; eapply lt_trans; eauto.
-      + left. unfold is_true in H2a. rewrite eqb_spec in H2a. now subst z.
-      + left. unfold is_true in H1a. rewrite eqb_spec in H1a. now subst y.
-      + right. split.
-        * unfold is_true in H1a. rewrite eqb_spec in H1a. now subst y.
-        * eapply IHxs; eauto.
-  Qed.
-
-
-  Lemma list_lt_not_eq : forall (x y : list A), list_lt x y -> x <> y.
-  Proof.
-    induction x as [ |x xs IHxs]; intros [ |y ys]; simpl; auto.
-    - discriminate.
-    - intros [H1|[H1 H2]]; intros H; inversion H; subst.
-      + eapply lt_not_eq; eauto.
-      + eapply IHxs; eauto.
-  Qed.
-
-
-  Instance list_ord : OrdType (list A) :=
-    Build_OrdType _ _ list_lt_trans list_lt_not_eq.
 
 
   Definition list_compare : forall (x y : list A), Compare list_lt Logic.eq x y.
@@ -738,21 +604,51 @@ Section list.
     - case_eq (compare x y); intros l H.
       + apply LT. simpl. now left.
       + case_eq (IHxs ys); intros l1 H1.
-        * apply LT. simpl. right. split; auto. now apply eqb_spec.
+        * apply LT. simpl. right. split; auto. now apply compare2eqb_spec.
         * apply EQ. now rewrite l, l1.
-        * apply GT. simpl. right. split; auto. now apply eqb_spec.
+        * apply GT. simpl. right. split; auto. now apply compare2eqb_spec.
       + apply GT. simpl. now left.
   Defined.
 
 
+  Lemma list_lt_trans : forall (x y z : list A),
+      list_lt x y -> list_lt y z -> list_lt x z.
+  Proof.
+    induction x as [ |x xs IHxs]; intros [ |y ys] [ |z zs]; simpl; auto.
+    - inversion 1.
+    - intros [H1|[H1a H1b]] [H2|[H2a H2b]].
+      + left; eapply lt_trans; eauto.
+      + left. unfold is_true in H2a. rewrite compare2eqb_spec in H2a. now subst z.
+      + left. unfold is_true in H1a. rewrite compare2eqb_spec in H1a. now subst y.
+      + right. split.
+        * unfold is_true in H1a. rewrite compare2eqb_spec in H1a. now subst y.
+        * eapply IHxs; eauto.
+  Qed.
+
+
+  Lemma list_lt_not_eq : forall (x y : list A), list_lt x y -> x <> y.
+  Proof.
+    induction x as [ |x xs IHxs]; intros [ |y ys]; simpl; auto.
+    - discriminate.
+    - intros [H1|[H1 H2]]; intros H; inversion H; subst.
+      + now apply (lt_not_eq _ _ H1).
+      + now apply (IHxs _ H2).
+  Qed.
+
+
+  Instance list_ord : OrdType (list A) :=
+    Build_OrdType _ _ list_lt_trans list_lt_not_eq.
+
+
   Instance list_comp : Comparable (list A) := Build_Comparable _ _ list_compare.
+
+  Instance list_eqbtype : EqbType (list A) := Comparable2EqbType.
 
 
   Instance list_inh : Inhabited (list A) := Build_Inhabited _ nil.
 
 
   Instance list_compdec : CompDec (list A) := {|
-    Eqb := list_eqbtype;
     Ordered := list_ord;
     Comp := list_comp;
     Inh := list_inh


### PR DESCRIPTION
Clean-up the definition of CompDec, leaving the required minimum (in particular for functional arrays)