### PR TITLE
[fix] Fix sed invocation in configure.sh

### DIFF
--- a/src/configure.sh
+++ b/src/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 coq_makefile -f _CoqProject -o Makefile
-sed -i 's/^CAMLDONTLINK=unix,str$/CAMLDONTLINK=num,str,unix,dynlink,threads/' Makefile
+sed -i '' 's/^CAMLDONTLINK=unix,str$/CAMLDONTLINK=num,str,unix,dynlink,threads/' Makefile


### PR DESCRIPTION
The sed command (line 4 in src/configure.sh) was used without an explicit argument for the option -i. This is undefined for some implementations of sed (for example on macOS). This results in the following error message:

```
#=== ERROR while compiling coq-smtcoq.2.0+8.11 ================================#
# context     2.1.3 | macos/arm64 | ocaml.4.10.2 | https://coq.inria.fr/opam/released#2022-11-15 19:00
# path        ~/Documents/smtcoqapi/_opam/.opam-switch/build/coq-smtcoq.2.0+8.11
# command     ~/.opam/opam-init/hooks/sandbox.sh build make -j7
# exit-code   2
# env-file    ~/.opam/log/coq-smtcoq-58182-44569a.env
# output-file ~/.opam/log/coq-smtcoq-58182-44569a.out
### output ###
# cd src && ./configure.sh && /Library/Developer/CommandLineTools/usr/bin/make
# sed: 1: "Makefile": invalid command code M
# make: *** [all] Error 1
```
