### PR TITLE
Remove .PHONY for smtcoq_plugin.mlpack.d in makefile

### DIFF
--- a/src/Makefile.local
+++ b/src/Makefile.local
@@ -40,5 +40,4 @@ merlin-hook::
 %.ml %.mli :  %.mly
 	$(CAMLYACC) $<
 
-.PHONY: smtcoq_plugin.mlpack.d
 smtcoq_plugin.mlpack.d :  verit/veritParser.ml verit/veritLexer.ml ../3rdparty/alt-ergo/smtlib2_parse.ml ../3rdparty/alt-ergo/smtlib2_lex.ml smtlib2/sExprParser.ml smtlib2/sExprLexer.ml lfsc/lfscParser.ml lfsc/lfscLexer.ml


### PR DESCRIPTION
Starting with `make` version `4.4` smtcoq's build started failing for me. I tracked it down to the `.PHONY` declaration of `smtcoq_plugin.mlpack.d`. For some reason, `make` is no longer creating this file. Not exactly sure why, but presumably it has something to do with the third incompatibility listed [here](https://lists.gnu.org/archive/html/info-gnu/2022-10/msg00008.html).

As far as I can tell, the `.PHONY` declaration doesn't really serve a purpose. So I deleted it.