### PR TITLE
Addresses the Term.decompose_prod_assum warning

### DIFF
--- a/src/trace/smtCommands.ml
+++ b/src/trace/smtCommands.ml
@@ -691,7 +691,7 @@ let of_coq_lemma rt ro ra_quant rf_quant env sigma solver_logic clemma =
     None
   in
 
-  let rel_context, qf_lemma = Term.decompose_prod_assum clemma in
+  let rel_context, qf_lemma = Term.decompose_prod_decls clemma in
   (* Bound variables are given fresh names to avoid variable capture *)
   let rel_context = List.map (fun rel -> Context.Rel.Declaration.set_name (Names.Name.mk_name (Names.Id.of_string (gen_rel_name ()))) rel) rel_context in
 

--- a/src/zchaff/zchaff.ml
+++ b/src/zchaff/zchaff.ml
@@ -517,7 +517,7 @@ let make_proof pform_tbl atom_tbl env reify_form l =
 let core_tactic vm_cast env sigma concl =
   SmtTrace.clear ();
 
-  let (forall_let, concl) = Term.decompose_prod_assum concl in
+  let (forall_let, concl) = Term.decompose_prod_decls concl in
   let a, b = get_arguments concl in
   let reify_atom = Atom.create () in
   let reify_form = Form.create () in


### PR DESCRIPTION
This trivial PR renames `Term.decompose_prod_assum` into `Term.decompose_prod_decls` in OCaml files, consistently with coq/coq#15582.