### PR TITLE
Adapt to Coq PR#18397: ComAssumption.declare_variable now takes a name, without a location

### DIFF
--- a/src/trace/coqInterface.ml
+++ b/src/trace/coqInterface.ml
@@ -75,11 +75,11 @@ let empty_named_universes_entry =
 
 (* TODO : Set -> Type *)
 let declare_new_type t =
-  let _ = ComAssumption.declare_variable Vernacexpr.NoCoercion ~kind:Decls.Definitional Constr.mkSet empty_named_universes_entry [] Glob_term.Explicit (CAst.make t) in
+  let _ = ComAssumption.declare_variable Vernacexpr.NoCoercion ~kind:Decls.Definitional Constr.mkSet empty_named_universes_entry [] Glob_term.Explicit t in
   Constr.mkVar t
 
 let declare_new_variable v constr_t =
-  let _ = ComAssumption.declare_variable Vernacexpr.NoCoercion ~kind:Decls.Definitional constr_t empty_named_universes_entry [] Glob_term.Explicit (CAst.make v) in
+  let _ = ComAssumption.declare_variable Vernacexpr.NoCoercion ~kind:Decls.Definitional constr_t empty_named_universes_entry [] Glob_term.Explicit v in
   Constr.mkVar v
 
 let declare_constant n c =


### PR DESCRIPTION
To be considered synchronously with coq/coq#18397.