### PR TITLE
Adapt to Coq PR #13445: new change in ComAssumptions.declare_variable

### DIFF
--- a/src/trace/coqInterface.ml
+++ b/src/trace/coqInterface.ml
@@ -75,11 +75,11 @@ let empty_named_universes_entry =
 
 (* TODO : Set -> Type *)
 let declare_new_type t =
-  let _ = ComAssumption.declare_variable Vernacexpr.NoCoercion ~kind:Decls.Definitional Constr.mkSet empty_named_universes_entry [] Glob_term.Explicit t in
+  let _ = ComAssumption.declare_variable ~coe:Vernacexpr.NoCoercion ~kind:Decls.Definitional ~univs:empty_named_universes_entry ~impargs:[] ~impl:Glob_term.Explicit ~name:t Constr.mkSet in
   Constr.mkVar t
 
 let declare_new_variable v constr_t =
-  let _ = ComAssumption.declare_variable Vernacexpr.NoCoercion ~kind:Decls.Definitional constr_t empty_named_universes_entry [] Glob_term.Explicit v in
+  let _ = ComAssumption.declare_variable ~coe:Vernacexpr.NoCoercion ~kind:Decls.Definitional ~univs:empty_named_universes_entry ~impargs:[] ~impl:Glob_term.Explicit ~name:v constr_t in
   Constr.mkVar v
 
 let declare_constant n c =


### PR DESCRIPTION
A new change to `ComAssumptions.declare_variable` which now takes labels (to follow the rule adopted in `declare.ml`).

To be merged synchronously.