### PR TITLE
Remove type annotation on object declaration (coq-master branch)

### DIFF
--- a/src/g_smtcoq.mlg
+++ b/src/g_smtcoq.mlg
@@ -89,7 +89,7 @@ let cache_lemmas lems =
 
 let declare_lemmas : CoqInterface.constr_expr list -> Libobject.obj =
   let open Libobject in
-  let obj : (CoqInterface.constr_expr list, CoqInterface.constr_expr list) object_declaration =
+  let obj =
     {
       (default_object "LEMMAS") with
       cache_function = cache_lemmas;


### PR DESCRIPTION
It's a bit fragile, cf https://github.com/coq/coq/pull/19353