### PR TITLE
Fix OCaml 5.x build: add num package to CAMLPKGS

### DIFF
--- a/src/CoqMakefile.local
+++ b/src/CoqMakefile.local
@@ -29,7 +29,8 @@ cleanall::
 
 CAMLLEX = $(CAMLBIN)ocamllex
 CAMLYACC = $(CAMLBIN)ocamlyacc
-CAMLPKGS += -package rocq-runtime.plugins.micromega
+# OCaml 5.x compatibility: num package provides Big_int module
+CAMLPKGS += -package num -package rocq-runtime.plugins.micromega
 
 merlin-hook::
 	$(HIDE)echo 'PKG num' >> .merlin


### PR DESCRIPTION
## Summary
Fix build failure on OCaml 5.x by adding `-package num` to compiler flags.

## Problem
On OCaml 5.x, the build fails with:
```
File "verit/veritParser.mly", line 46, characters 8-23:
Error: Unbound module Big_int
```

## Root Cause
In OCaml 5.0, the `Big_int` module was removed from the standard library and moved to the `num` package. The `num` package is listed in the opam dependencies but wasn't being linked during compilation.

## Solution
Add `-package num` to `CAMLPKGS` in `src/CoqMakefile.local` so ocamlfind includes the num package during compilation.

## Testing
- Tested with OCaml 5.1.1, Rocq 9.0.1 on Linux
- Build completes successfully
- Basic SMTCoq tactics work (tested with cvc4)

Fixes #160