### PR TITLE
Add option SMTCoq Print Solver Status, don't print to Rocq's stderr

### DIFF
--- a/src/_CoqProject
+++ b/src/_CoqProject
@@ -59,6 +59,7 @@ trace/smtMisc.ml
 trace/smtMisc.mli
 trace/smtTrace.ml
 trace/smtTrace.mli
+trace/solverStatus.ml
 trace/coqInterface.ml
 trace/coqInterface.mli
 

--- a/src/g_smtcoq.mlg
+++ b/src/g_smtcoq.mlg
@@ -17,6 +17,8 @@ DECLARE PLUGIN "coq-smtcoq.smtcoq"
 open Stdarg
 open Ltac_plugin
 
+let _ = CoqInterface.print_solver_status ()
+
 }
 
 VERNAC COMMAND EXTEND Vernac_zchaff CLASSIFIED AS QUERY

--- a/src/lfsc/lfsc.ml
+++ b/src/lfsc/lfsc.ml
@@ -78,7 +78,7 @@ let lfsc_parse_one lb =
   let t1 = Sys.time () in
   printf " Done [%.3f s]@." (t1 -. t0);
   r
-  
+
 
 let import_trace first parse lexbuf =
   Printexc.record_backtrace true;
@@ -251,7 +251,7 @@ let checker fsmt fproof =
 (*   (\* Just for printing *\) *)
 
 (*   open Atom *)
-  
+
 (*   let distrib x l = List.map (fun y -> (x,y)) l *)
 
 (*   let rec cross acc l = match l with *)
@@ -260,7 +260,7 @@ let checker fsmt fproof =
 (*       cross (List.rev_append (distrib x r) acc) r *)
 
 (*   let cross = cross [] *)
-  
+
 (*   let rec compute_int = function *)
 (*     | Acop c -> *)
 (*       (match c with *)
@@ -314,7 +314,7 @@ let checker fsmt fproof =
 (*       | BO_Zge -> ">=" *)
 (*       | BO_Zgt -> ">" *)
 (*       | BO_eq _ -> "=" *)
-  
+
 (*   and to_smt_bop fmt op h1 h2 = *)
 (*     match op with *)
 (*     | BO_Zlt -> fprintf fmt "(not (>= %a %a)" to_smt h1 to_smt h2 *)
@@ -373,11 +373,11 @@ let call_abduce i env rt ro ra rf root lsmt =
     List.iter (fun x -> assume cvc5 (asprintf "%a" (Form.to_smt ~debug:false) x)) (List.tl lsmt);
 
     let proof =
-      let abduct1 = SmtCommands.abduct_string env rt ro ra rf 
+      let abduct1 = SmtCommands.abduct_string env rt ro ra rf
             (get_abduct cvc5 (asprintf "%a" (Form.to_smt ~debug:false) fl)) in
       let rec produce_abducts n =
         (if n > 0 then
-          (SmtCommands.abduct_string env rt ro ra rf (get_abduct_next cvc5)) :: produce_abducts (n-1) 
+          (SmtCommands.abduct_string env rt ro ra rf (get_abduct_next cvc5)) :: produce_abducts (n-1)
         else []) in
       let abducts = List.rev (produce_abducts (i - 1)) in
         CoqInterface.error
@@ -458,7 +458,7 @@ let call_cvc4 _ env rt ro ra rf root lsmt =
     SmtMaps.add_btype s (SmtBtype.Tindex t);
     declare_sort cvc4 s 0;
   ) (SmtBtype.to_list rt);
-  
+
   (* Declare functions and variables *)
   List.iter (fun (i,cod,dom,op) ->
     let s = "op_"^(string_of_int i) in
@@ -530,7 +530,6 @@ let get_model_from_file filename =
   | [SExpr.Atom "sat"; m] -> m
   | _ -> CoqInterface.error "CVC4 returned SAT but no model"
 
-
 let call_cvc4_file _ env rt ro ra rf root =
   let fl = snd root in
   let (filename, outchan) = Filename.open_temp_file "cvc4_coq" ".smt2" in
@@ -538,6 +537,8 @@ let call_cvc4_file _ env rt ro ra rf root =
   close_out outchan;
   let bf = Filename.chop_extension filename in
   let prooffilename = bf ^ ".lfsc" in
+  let errfilename, errchan = Filename.open_temp_file "stderr_cvc4" ".log" in
+  close_out errchan;
 
   (* let cvc4_cmd = *)
   (*   "cvc4 --proof --dump-proof -m --dump-model \ *)
@@ -545,22 +546,25 @@ let call_cvc4_file _ env rt ro ra rf root =
   (*    --no-bv-eq --no-bv-ineq --no-bv-algebraic " *)
   (*   ^ filename ^ " > " ^ prooffilename in *)
   (* CVC4 crashes when asking for both models and proofs *)
-  
+
   let cvc4_cmd =
     "cvc4 --proof --dump-proof \
      --simplification=none --fewer-preprocessing-holes \
      --no-bv-eq --no-bv-ineq --no-bv-algebraic "
-    ^ filename ^ " > " ^ prooffilename in
+    ^ filename ^ " > " ^ prooffilename ^ " 2> " ^ errfilename in
   (* let clean_cmd = "sed -i -e '1d' " ^ prooffilename in *)
   CoqInterface.msg_solver_status cvc4_cmd;
   let t0 = Sys.time () in
   let exit_code = Sys.command cvc4_cmd in
-  
+  SolverStatus.msg_file errfilename;
+  Sys.remove errfilename;
+
   let t1 = Sys.time () in
   CoqInterface.msg_solver_status (Printf.sprintf "CVC4 = %.5f" (t1 -. t0));
 
-  if exit_code <> 0 then
+  if exit_code <> 0 then begin
     CoqInterface.error ("CVC4 crashed: return code "^string_of_int exit_code);
+  end;
 
   (* ignore (Sys.command clean_cmd); *)
 
@@ -575,7 +579,7 @@ let call_cvc4_file _ env rt ro ra rf root =
        SmtCommands.model_string env rt ro ra rf smodel)
 
 
-let cvc4_logic = 
+let cvc4_logic =
   SL.of_list [LUF; LLia; LBitvectors; LArrays]
 
 

--- a/src/lfsc/lfsc.ml
+++ b/src/lfsc/lfsc.ml
@@ -552,12 +552,12 @@ let call_cvc4_file _ env rt ro ra rf root =
      --no-bv-eq --no-bv-ineq --no-bv-algebraic "
     ^ filename ^ " > " ^ prooffilename in
   (* let clean_cmd = "sed -i -e '1d' " ^ prooffilename in *)
-  eprintf "%s@." cvc4_cmd;
+  CoqInterface.msg_solver_status cvc4_cmd;
   let t0 = Sys.time () in
   let exit_code = Sys.command cvc4_cmd in
   
   let t1 = Sys.time () in
-  eprintf "CVC4 = %.5f@." (t1-.t0);
+  CoqInterface.msg_solver_status (Printf.sprintf "CVC4 = %.5f" (t1 -. t0));
 
   if exit_code <> 0 then
     CoqInterface.error ("CVC4 crashed: return code "^string_of_int exit_code);

--- a/src/smtcoq_plugin.mlpack
+++ b/src/smtcoq_plugin.mlpack
@@ -1,4 +1,5 @@
 CoqInterface
+SolverStatus
 
 SmtMisc
 CoqTerms

--- a/src/smtlib2/smtlib2_solver.ml
+++ b/src/smtlib2/smtlib2_solver.ml
@@ -93,7 +93,7 @@ let read_check_result s =
 
 
 let send_command s cmd read =
-  eprintf "%s@." cmd;
+  CoqInterface.msg_solver_status cmd;
   (* let err_p1 = Unix.((fstat s.stderr).st_size) in *)
   try
     let in_ch = Unix.out_channel_of_descr s.stdin in
@@ -175,5 +175,4 @@ let quit s =
     send_command s "(exit)" read_success;
   with Unix.Unix_error _ -> ();
   kill s
-
 

--- a/src/trace/coqInterface.ml
+++ b/src/trace/coqInterface.ml
@@ -157,6 +157,15 @@ type constr_expr = Constrexpr.constr_expr
 let error s = CErrors.user_err (Pp.str s)
 let anomaly s = CErrors.anomaly (Pp.str s)
 
+let { Goptions.get = print_solver_status } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["SMTCoq"; "Print"; "Solver"; "Status"]
+    ~value:false
+    ()
+
+let msg_solver_status s =
+  if print_solver_status () then Feedback.msg_info (Pp.str s)
+
 let smtcoq_cat = CWarnings.create_category ~name:"SMTCoq" ()
 
 let destruct_rel_decl r = Context.Rel.Declaration.get_name r,

--- a/src/trace/coqInterface.mli
+++ b/src/trace/coqInterface.mli
@@ -100,6 +100,8 @@ val set_evars_tac : constr -> tactic
 type constr_expr = Constrexpr.constr_expr
 val error : string -> 'a
 val anomaly : string -> 'a
+val print_solver_status : unit -> bool
+val msg_solver_status : string -> unit
 
 val smtcoq_cat : CWarnings.category
 

--- a/src/trace/solverStatus.ml
+++ b/src/trace/solverStatus.ml
@@ -1,0 +1,21 @@
+(**************************************************************************)
+(*                                                                        *)
+(*     SMTCoq                                                             *)
+(*     Copyright (C) 2011 - 2026                                          *)
+(*                                                                        *)
+(*     See file "AUTHORS" for the list of authors                         *)
+(*                                                                        *)
+(*   This file is distributed under the terms of the CeCILL-C licence     *)
+(*                                                                        *)
+(**************************************************************************)
+
+let msg_file filename =
+  if CoqInterface.print_solver_status () then
+    try
+      let ic = open_in filename in
+      (try
+         while true do
+           CoqInterface.msg_solver_status (input_line ic)
+         done
+       with End_of_file -> close_in ic)
+    with Sys_error _ -> ()

--- a/src/verit/verit.ml
+++ b/src/verit/verit.ml
@@ -199,11 +199,11 @@ let call_verit timeout _ _ rt ro ra_quant rf_quant first lsmt =
       | Some i -> "timeout "^(string_of_int i)^" "^command
       | None -> command
   in
-  Format.eprintf "%s@." command;
+  CoqInterface.msg_solver_status command;
   let t0 = Sys.time () in
   let exit_code = Sys.command command in
   let t1 = Sys.time () in
-  Format.eprintf "Verit = %.5f@." (t1-.t0);
+  CoqInterface.msg_solver_status (Printf.sprintf "Verit = %.5f" (t1 -. t0));
 
   let win = open_in wname in
 
@@ -260,4 +260,3 @@ let tactic_gen vm_cast timeout lcpl lcepl =
   SmtCommands.tactic 0 (call_verit timeout) verit_logic rt ro ra rf ra_quant rf_quant vm_cast lcpl lcepl
 let tactic = tactic_gen vm_cast_true
 let tactic_no_check = tactic_gen (fun _ -> vm_cast_true_no_check)
-

--- a/src/verit/verit.ml
+++ b/src/verit/verit.ml
@@ -193,7 +193,9 @@ let call_verit timeout _ _ rt ro ra_quant rf_quant first lsmt =
   let logfilename = Filename.chop_extension filename ^ ".vtlog" in
   let wname, woc = Filename.open_temp_file "warnings_verit" ".log" in
   close_out woc;
-  let command = "veriT --proof-prune --proof-merge --proof-with-sharing --cnf-definitional --disable-ackermann --input=smtlib2 --proof=" ^ logfilename ^ " " ^ filename ^ " 2> " ^ wname in
+  let oname, ooc = Filename.open_temp_file "stdout_verit" ".log" in
+  close_out ooc;
+  let command = "veriT --proof-prune --proof-merge --proof-with-sharing --cnf-definitional --disable-ackermann --input=smtlib2 --proof=" ^ logfilename ^ " " ^ filename ^ " > " ^ oname ^ " 2> " ^ wname in
   let command = 
     match timeout with
       | Some i -> "timeout "^(string_of_int i)^" "^command
@@ -203,6 +205,7 @@ let call_verit timeout _ _ rt ro ra_quant rf_quant first lsmt =
   let t0 = Sys.time () in
   let exit_code = Sys.command command in
   let t1 = Sys.time () in
+  SolverStatus.msg_file oname;
   CoqInterface.msg_solver_status (Printf.sprintf "Verit = %.5f" (t1 -. t0));
 
   let win = open_in wname in
@@ -224,13 +227,13 @@ let call_verit timeout _ _ rt ro ra_quant rf_quant first lsmt =
           CoqInterface.error ("veriT failed with the error: " ^ l)
       done
     with End_of_file -> () in
-  if exit_code = 124 (*code for timeout*) then (close_in win; Sys.remove wname; let _ = CoqInterface.anomaly "veriT timed out" in ());
+  if exit_code = 124 (*code for timeout*) then (close_in win; Sys.remove wname; Sys.remove oname; let _ = CoqInterface.anomaly "veriT timed out" in ());
   try
     if exit_code <> 0 then verit_non_zero_exit (command,exit_code);
     raise_warnings_errors ();
     let res = import_trace ra_quant rf_quant logfilename (Some first) lsmt in
-    close_in win; Sys.remove wname; res
-  with x -> close_in win; Sys.remove wname;
+    close_in win; Sys.remove wname; Sys.remove oname; res
+  with x -> close_in win; Sys.remove wname; Sys.remove oname;
             match x with
             | Unknown -> CoqInterface.error "veriT returns 'unknown'"
             | VeritSyntax.Sat -> CoqInterface.error "veriT found a counter-example"

--- a/src/zchaff/zchaff.ml
+++ b/src/zchaff/zchaff.ml
@@ -319,17 +319,23 @@ let export out_channel nvars first =
 let call_zchaff nvars root =
   let (filename, outchan) = Filename.open_temp_file "zchaff_coq" ".cnf" in
   let resfilename = (Filename.chop_extension filename)^".zlog" in
+  let errfilename, errchan = Filename.open_temp_file "stderr_zchaff" ".log" in
+  close_out errchan;
   let reloc, last = export outchan nvars root in
   close_out outchan;
-  let command = "zchaff " ^ filename ^ " > " ^ resfilename in
+  let command = "zchaff " ^ filename ^ " > " ^ resfilename ^ " 2> " ^ errfilename in
   CoqInterface.msg_solver_status command;
   let t0 = Sys.time () in
   let exit_code = Sys.command command in
   let t1 = Sys.time () in
+  SolverStatus.msg_file errfilename;
+  Sys.remove errfilename;
+
   CoqInterface.msg_solver_status (Printf.sprintf "Zchaff = %.5f" (t1 -. t0));
-  if exit_code <> 0 then
+  if exit_code <> 0 then begin
     failwith ("Zchaff.call_zchaff: command " ^ command ^
-	        " exited with code " ^ (string_of_int exit_code));
+                " exited with code " ^ (string_of_int exit_code))
+  end;
   let logfilename = (Filename.chop_extension filename) ^ ".log" in
   let command2 = "mv resolve_trace "^logfilename in
   let exit_code2 = Sys.command command2 in

--- a/src/zchaff/zchaff.ml
+++ b/src/zchaff/zchaff.ml
@@ -322,11 +322,11 @@ let call_zchaff nvars root =
   let reloc, last = export outchan nvars root in
   close_out outchan;
   let command = "zchaff " ^ filename ^ " > " ^ resfilename in
-  Format.eprintf "%s@." command;
+  CoqInterface.msg_solver_status command;
   let t0 = Sys.time () in
   let exit_code = Sys.command command in
   let t1 = Sys.time () in
-  Format.eprintf "Zchaff = %.5f@." (t1-.t0);
+  CoqInterface.msg_solver_status (Printf.sprintf "Zchaff = %.5f" (t1 -. t0));
   if exit_code <> 0 then
     failwith ("Zchaff.call_zchaff: command " ^ command ^
 	        " exited with code " ^ (string_of_int exit_code));


### PR DESCRIPTION
The current behavior of outputting solver status on Rocq's stderr + stdout doesn't work very well with Rocq frontends like Coqtail, which don't expect these kinds of messages on Rocq's stderr in their default config.

Therefore, this adds an opt-in Rocq flag, `SMTCoq Print Solver Status`, to control solver-status logging. By default, no status of the solvers is output, but this can be enabled with the flag; then, the existing messages will be output via Rocq's info messages (instead of via stdout/stderr).

- Replaces direct eprintf status prints with Feedback.msg_info, gated by the new flag.
- Ensures the flag is registered at plugin initialization.
- Captures solver process output from Sys.command redirections and re-emits it through Rocq feedback when enabled (instead of leaking to raw stderr/stdout).
- Introduces a shared internal helper (SolverStatus) to avoid duplicated file-to-feedback logic.